### PR TITLE
Fix validation and wallet checks

### DIFF
--- a/dht/dht.py
+++ b/dht/dht.py
@@ -10,7 +10,7 @@ from config.config import shutdown_event, VALIDATOR_ID, HEARTBEAT_INTERVAL, VALI
 from state.state import validator_keys, known_validators
 from blockchain.blockchain import calculate_merkle_root
 from database.database import get_db,get_current_height
-from wallet.wallet import verify_transaction
+from wallet.wallet import verify_transaction_and_address
 
 kad_server = None
 
@@ -335,11 +335,7 @@ async def push_blocks(peer_ip, peer_port):
                         for output_ in outputs:
                             output_receiver = output_.get("receiver")
                             output_amount = output_.get("amount", "0")
-                            if output_receiver in (to_, ADMIN_ADDRESS):
-                                total_required += Decimal(output_amount)
-                            else:
-                                print(f"❌ Hack detected! Unauthorized output to {output_receiver}")
-                                raise ValueError("Hack detected, invalid transaction.")
+                            total_required += Decimal(output_amount)
 
                         print(total_authorized)
 
@@ -352,7 +348,7 @@ async def push_blocks(peer_ip, peer_port):
                                 raise ValueError("Invalid transaction: insufficient balance.")
                         
 
-                        if height == 0 or (verify_transaction(message_str, signature, pubkey) == True):
+                        if height == 0 or (verify_transaction_and_address(message_str, signature, pubkey) == True):
                             print("✅ Transaction validated successfully.")
                             batch = WriteBatch()
 

--- a/web/web.py
+++ b/web/web.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI, WebSocket, WebSocketDisconnect, Request, Depends
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from database.database import get_db, get_current_height
-from wallet.wallet import  verify_transaction
+from wallet.wallet import  verify_transaction_and_address
 from pydantic import BaseModel
 from typing import Dict, List, Set, Optional
 from decimal import Decimal, InvalidOperation
@@ -426,7 +426,7 @@ async def worker_endpoint(request: Request):
         sender_, receiver_, send_amount = parts[0], parts[1], parts[2]
         nonce = parts[3] if len(parts) > 3 else str(int(time.time() * 1000))
         
-        if not verify_transaction(message_str, signature_hex, pubkey_hex):
+        if not verify_transaction_and_address(message_str, signature_hex, pubkey_hex):
             return {"status": "error", "message": "Invalid signature"}
 
         inputs = []


### PR DESCRIPTION
## Summary
- bind transactions to signer address
- allow change outputs
- check intra-block double spends
- reuse JS crypto contexts

## Testing
- `python -m py_compile wallet/wallet.py gossip/gossip.py dht/dht.py rpc/rpc.py web/web.py`

------
https://chatgpt.com/codex/tasks/task_e_6840c2cd9c148322813f1d158460b447